### PR TITLE
add browserify to devDependencies

### DIFF
--- a/implementations/base/package.json
+++ b/implementations/base/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "bower": "^1.3.12",
+    "browserify": "^8.1.0",
     "eslint": "^0.11.0",
     "node-sass": "^2.0.0-beta",
     "tape": "^3.0.3",

--- a/implementations/npm/package.json
+++ b/implementations/npm/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "bower": "^1.3.12",
+    "browserify": "^8.1.0",
     "eslint": "^0.11.0",
     "exorcist": "^0.1.6",
     "minifyify": "^5.0.0",


### PR DESCRIPTION
Notice it was missing when running `npm run build` (assuming the developer had it installed globally). Things work great now.