### PR TITLE
create dist directory on clean if it does not exist

### DIFF
--- a/implementations/npm/package.json
+++ b/implementations/npm/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "postinstall": "bower install",
-    "clean": "rimraf dist/*",
+    "clean": "rimraf dist && mkdirp dist",
     "lint": "eslint js/**.js test/*.js",
     "compile:styles": "node-sass bower_components/todomvc-common/*.css dist/app.css",
     "compile": "browserify js/app.js -d -p [minifyify --map app.map.json --output dist/app.map.json] > dist/app.js",
@@ -53,6 +53,7 @@
     "faucet": "0.0.1",
     "http-server": "^0.7.4",
     "minifyify": "^5.0.0",
+    "mkdirp": "^0.5.0",
     "node-sass": "^2.0.0-beta",
     "parallelshell": "^1.0.3",
     "rimraf": "^2.2.8",


### PR DESCRIPTION
Was having problems running npm build on a fresh copy of the npm implementation as the `dist` directory did not exist. Added a step to the clean script to `mkdirp dist` so this won't happen