### PR TITLE
add script to clone base using "npm run clone" Closes #5

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.0",
   "description": "Helping you select your task runners.",
   "main": "index.js",
-  "scripts": {},
+  "scripts": {
+    "clone": "node scripts/clonebase.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ericelliott/todotasks.git"
@@ -28,6 +30,9 @@
     "bower": "^1.3.12"
   },
   "devDependencies": {
+    "ask-for": "0.0.3",
+    "chalk": "^0.5.1",
+    "directory-copy": "^0.1.0",
     "eslint": "^0.11.0",
     "node-sass": "^2.0.0-beta",
     "tape": "^3.0.3",

--- a/scripts/clonebase.js
+++ b/scripts/clonebase.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var copy = require('directory-copy');
+var askFor = require('ask-for');
+var chalk = require('chalk');
+
+var implName = process.argv[2];
+
+
+function copyBase(name) {
+	var src = path.normalize(path.join(__dirname, '/../implementations/base'));
+	var dest = path.normalize(path.join(__dirname, '/../implementations/', name));
+
+	console.log('Copying from ' + chalk.blue(src));
+	if (fs.existsSync(dest)) {
+		console.error(chalk.red('Error: directory already exists: ') + dest);
+		console.error('Please choose another name.');
+		return;
+	}
+
+	copy({
+		src: src,
+		dest: dest
+	}, function () {
+		console.log(chalk.green('Created new implementation at ' + dest));
+	});
+}
+
+
+if (!implName) {
+	askFor(['Implementation Name'], function (answers) {
+		copyBase(answers['Implementation Name']);
+	});
+} else {
+	copyBase(implName);
+}


### PR DESCRIPTION
This addresses #5

How to use:

```bash
npm run clone sometaskrunner

> todotasks@1.0.0 clone /home/flet/code/todotasks
> node scripts/clonebase.js sometaskrunner

Copying from /home/flet/code/todotasks/implementations/base
Created new implementation at /home/flet/code/todotasks/implementations/sometaskrunner
```

It will also accept this
```bash
npm run clone
```

and prompt for a name:
```bash
Implementation Name: hello
Copying from /home/icmpdev/code/todotasks/implementations/base
Created new implementation at /home/flet/code/todotasks/implementations/hello
```

Also basic validation to ensure existing directories are not blown away:
```bash
npm run clone sometaskrunner

> todotasks@1.0.0 clone /home/flet/code/todotasks
> node scripts/clonebase.js sometaskrunner

Copying from /home/flet/code/todotasks/implementations/base
Error: directory already exists: /home/flet/code/todotasks/implementations/sometaskrunner
Please choose another name.
```

Pretty basic, but gets the job done...